### PR TITLE
Feat: added refresh token to Google provider

### DIFF
--- a/src/pages/api/calendar/oauth2.ts
+++ b/src/pages/api/calendar/oauth2.ts
@@ -13,10 +13,11 @@ export async function getOAuth2Client(
   const session = await getServerSession(req, res, options);
 
   const token = await getToken({ req });
+
   if (!session || !token) signIn();
 
-  const accessToken = token?.accessToken as string;
-  const refreshToken = token?.refreshToken as string;
+  const accessToken = token?.access_token as string;
+  const refreshToken = token?.refresh_token as string;
 
   if (!accessToken) throw Error("Access Token not found.");
 


### PR DESCRIPTION
Greetings Mr. Alexandrino,

To resolve issue #9, the refresh token rotation was implemented by the Next Auth example: [refresh-token-rotation](https://authjs.dev/guides/refresh-token-rotation)

According to the [OAuth2 documentation](https://developers.google.com/identity/protocols/oauth2 ), the token in testing mode expires in 1 hour, when used with a refresh token, it can last up to 7 days, the periods change when the application is published.

> A Google Cloud Platform project with an OAuth consent screen configured for an external user type and a publishing status of "Testing" is issued a refresh token expiring in 7 days

Best regards